### PR TITLE
Updated LLVM to version 18 and bum host-spawn to 1.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ flatpak install org.flatpak.Builder
 Additionaly, if you want you can install dependencies manualy, by running following commands:
 ```bash
 flatpak install flathub org.gnome.Platform
-flatpak install org.freedesktop.Sdk.Extension.llvm17
+flatpak install org.freedesktop.Sdk.Extension.llvm18
 flatpak install org.freedesktop.Sdk.Extension.golang
 ```
 

--- a/org.ultimatepp.TheIDE.metainfo.xml
+++ b/org.ultimatepp.TheIDE.metainfo.xml
@@ -46,31 +46,31 @@
     <url type="donation">https://www.ultimatepp.org/www$uppweb$Funding$en-us.html</url>
     <screenshots>
         <screenshot type="default">
-            <image xml:lang="en">https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/1.png</image>
+            <image>https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/1.png</image>
             <caption>TheIDE main view with opened code editor</caption>
         </screenshot>
-        <screenshot type="default">
-            <image xml:lang="en">https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/2.png</image>
+        <screenshot>
+            <image>https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/2.png</image>
             <caption>TheIDE main view with opened code editor - dark variant</caption>
         </screenshot>
-        <screenshot type="default">
-            <image xml:lang="en">https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/3.png</image>
+        <screenshot>
+            <image>https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/3.png</image>
             <caption>TheIDE layout designer</caption>
         </screenshot>
-        <screenshot type="default">
-            <image xml:lang="en">https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/4.png</image>
+        <screenshot>
+            <image>https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/4.png</image>
             <caption>TheIDE icon designer</caption>
         </screenshot>
-        <screenshot type="default">
-            <image xml:lang="en">https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/5.png</image>
+        <screenshot>
+            <image>https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/5.png</image>
             <caption>TheIDE help view</caption>
         </screenshot>
-        <screenshot type="default">
-            <image xml:lang="en">https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/6.png</image>
+        <screenshot>
+            <image>https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/6.png</image>
             <caption>TheIDE topic editor</caption>
         </screenshot>
-        <screenshot type="default">
-            <image xml:lang="en">https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/7.png</image>
+        <screenshot>
+            <image>https://raw.githubusercontent.com/ultimatepp/static/main/screenshots/flathub/2023.2/7.png</image>
             <caption>TheIDE debugging</caption>
         </screenshot>
     </screenshots>

--- a/org.ultimatepp.TheIDE.yml
+++ b/org.ultimatepp.TheIDE.yml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: "23.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - "org.freedesktop.Sdk.Extension.llvm17"
+  - "org.freedesktop.Sdk.Extension.llvm18"
   - "org.freedesktop.Sdk.Extension.golang"
 command: run-ide.sh
 cleanup:
@@ -54,10 +54,11 @@ modules:
       - cp .clang-format /app/src/uppsrc/.clang-format
       - cp uppbox/Scripts/GCCMK.bm /app/bm/GCC.bm
       - cp run-ide-install-host-deps.sh /app/src/run-ide-install-host-deps.sh
-      - cp /usr/lib/sdk/llvm17/lib/libLLVM-17.so /app/lib/
-      - cp /usr/lib/sdk/llvm17/lib/libLLVMTableGen.so.17 /app/lib/
-      - cp /usr/lib/sdk/llvm17/lib/libclang.so.17 /app/lib/
-      - cp /usr/lib/sdk/llvm17/lib/LLVMgold.so /app/lib/
+      - cp -a /usr/lib/sdk/llvm18/lib/libLLVM* /app/lib/
+      - cp -a /usr/lib/sdk/llvm18/lib/libLLVMTableGen.so* /app/lib/
+      - cp -a /usr/lib/sdk/llvm18/lib/libclang.so* /app/lib/
+      - cp -a /usr/lib/sdk/llvm18/lib/libclang-cpp.so* /app/lib/
+      - cp /usr/lib/sdk/llvm18/lib/LLVMgold.so /app/lib/
     sources:
       - type: archive
         url: https://github.com/ultimatepp/ultimatepp/archive/refs/tags/2023.2.tar.gz
@@ -109,8 +110,8 @@ modules:
       - install -Dm755 host-spawn /app/bin/host-spawn
     sources:
       - type: archive
-        url: https://github.com/1player/host-spawn/archive/refs/tags/v1.5.1.tar.gz
-        sha256: cc62c0584731c43b25b57a08136682a8def357e273de4606192a4b33abde84f2
+        url: https://github.com/1player/host-spawn/archive/refs/tags/v1.6.0.tar.gz
+        sha256: 62048a0dc058b7a58e66d1a4f856f3987f8f63d3dc41e5d8df48cb23cc9400e7
       - type: git
         url: https://github.com/godbus/dbus
         tag: v5.1.0


### PR DESCRIPTION
Things done in this PR:
- Migrated from LLVM17 to LLVM18
- Added "-a" to cp while copying clang libraries to avoid basing on hard-coded versions
- Bump host-spawn to version 1.6.0